### PR TITLE
Corrected out of memory error with zero-sized files

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function CSVToArray( strData, strDelimiter ){
   // matching groups.
   var arrMatches = null;
 
+  if(strData.length == 0) return (arrData);
 
   // Keep looping over the regular expression matches
   // until we can no longer find a match.


### PR DESCRIPTION
According to the issue I made, there is the correction: added a test to return the array if the file's length is 0
